### PR TITLE
Index by run ID so removal works properly

### DIFF
--- a/src/lib/Runs.svelte
+++ b/src/lib/Runs.svelte
@@ -18,7 +18,7 @@
   <h2 class="font-bold">Runs <small class="text-xs font-normal">({$runs.length})</small></h2>
   {#if $runs.length}
     <div class="flex flex-wrap gap-2">
-      {#each sortedRuns as run}
+      {#each sortedRuns as run (run.id)}
         <RunItem {run} on:deleteRun={(e) => deleteRun(e)} />
       {/each}
     </div>


### PR DESCRIPTION
Without this change, removing an item will not remove the correct run.