### PR TITLE
add scale param and minor ux improvements

### DIFF
--- a/src/Generate.svelte
+++ b/src/Generate.svelte
@@ -267,15 +267,22 @@
 
       <label class="flex flex-col">
         <span class="font-bold">Image Height</span>
-        <!-- must be a multiple of 16 -->
-        <input type="number" bind:value={height} min="1" step="16" class="w-32" />
+        <!-- must be a multiple of 8 -->
+        <input type="number" bind:value={height} min="1" step="8" class="w-32" />
       </label>
 
       <label class="flex flex-col">
         <span class="font-bold">Image Width</span>
-        <!-- must be a multiple of 16 -->
-        <input type="number" bind:value={width} min="1" step="16" class="w-32" />
+        <!-- must be a multiple of 8 -->
+        <input type="number" bind:value={width} min="1" step="8" class="w-32" />
       </label>
+
+      {#if (width !== 512) && (height !== 512)}
+        <div class="flex flex-col">
+          <span class="font-bold">Dimension validation warning</span>
+          <span class="text-red-500">Either Height or Width should be 512 for best results (<a class="text-blue-400 hover:text-blue-200" href="https://huggingface.co/blog/stable_diffusion">source</a>)</span>
+        </div>
+      {/if}
 
       <label class="flex flex-col">
         <span class="font-bold">Seed</span>

--- a/src/Generate.svelte
+++ b/src/Generate.svelte
@@ -35,9 +35,9 @@
   let steps: number = defaultSteps; // selected steps
   let maxSteps: number = 100;
   let stepsOptions: number[] = [1, 2, 3, 4, 5, 10, 15, 25, 50, 75, 100];
-  let defaultScale: number = 1; // --scale, default 1
+  let defaultScale: number = 8; // --scale, default 7.5 but we round to 8
   let scale: number = defaultScale; // selected scale (context free guidance)
-  let maxScale: number = 20; // 1 is AI decides, 20 is "stick to my prompt"
+  let maxScale: number = 20; // 1 is AI almost ignores prompt, 20 is "stick to my prompt"
   let defaultIter: number = 1; // --n_iter, default 1
   let iter: number = defaultIter; // selected iter(ations?)
   let maxIter: number = 10; // no idea what is should be, go with 10 for now

--- a/src/Generate.svelte
+++ b/src/Generate.svelte
@@ -31,7 +31,7 @@
   const placeholder =
     "a red juicy apple floating in outer space, like a planet";
   let prompt: string = "";
-  let defaultSteps: number = 10; // --ddim_steps, default 50
+  let defaultSteps: number = 50; // --ddim_steps, default 50
   let steps: number = defaultSteps; // selected steps
   let maxSteps: number = 100;
   let stepsOptions: number[] = [1, 2, 3, 4, 5, 10, 15, 25, 50, 75, 100];


### PR DESCRIPTION
minor improvements as mentioned in https://github.com/breadthe/sd-buddy/discussions/6#discussioncomment-3581443

- add `--scale` param - very important for context free guidance!
- add max token length warning
- height and width must be multiples of 16